### PR TITLE
fix: revert right encoder C_NEXT/C_PREV → PG_UP/PG_DN

### DIFF
--- a/config/boards/shields/sweep/sweep.keymap
+++ b/config/boards/shields/sweep/sweep.keymap
@@ -60,7 +60,7 @@
                 KM_BASE_R2
                 &kp C_MUTE  KM_MID_T  &kp C_PP
             >;
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp C_NEXT C_PREV>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         numbers_layer {
@@ -119,7 +119,7 @@
                 // ENC-L        NUM/TAB  NAV/SPC  FUN/RET  SYM/ESC  ENC-R
                 &bootloader  &trans  &trans  &trans  &trans  &sys_reset
             >;
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp C_NEXT C_PREV>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         functions_layer {
@@ -130,7 +130,7 @@
                 KM_FUNC_R2
                 KM_FUNC_T
             >;
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp C_NEXT C_PREV>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         // Sweep-exclusive: cirque trackpad mouse layer


### PR DESCRIPTION
## Problem

After PR #10, the right encoder rotation wasn't working in base, system, and functions layers.

## Root cause

PR #10 changed the right encoder from `PG_UP`/`PG_DN` to `C_NEXT`/`C_PREV` in these layers. `C_NEXT`/`C_PREV` are consumer control keycodes that don't work reliably with `&inc_dec_kp` (they're fine with `&kp` in the media layer row bindings, but encoder rotation seems to need keyboard-page keycodes).

## Fix

Reverted the right encoder back to `PG_UP`/`PG_DN` in base, system, and functions layers. The media layer keeps `C_NEXT`/`C_PREV` since that was the original behavior before PR #10.

| Layer | Left encoder | Right encoder |
|-------|-------------|---------------|
| Base | C_VOL+/− | **PG_UP/PG_DN** |
| System | C_VOL+/− | **PG_UP/PG_DN** |
| Functions | C_VOL+/− | **PG_UP/PG_DN** |
| Media | C_VOL+/− | C_NEXT/C_PREV |

## Files changed

| File | Change |
|------|--------|
| `sweep.keymap` | 3 lines — C_NEXT/C_PREV → PG_UP/PG_DN |

🤖 Generated with [Claude Code](https://claude.com/claude-code)