### PR TITLE
fix: outer thumb keys for media/system, encoder config, trackpad speed, transform alignment

### DIFF
--- a/config/behaviors/keymap_layers.h
+++ b/config/behaviors/keymap_layers.h
@@ -18,20 +18,8 @@
 #define SYSTEM    5
 #define FUNCTIONS 6
 
-// ─── Conditional layers (NAV+SYMBOLS→MEDIA, NUMBERS+FUNCTIONS→SYSTEM) ──────
-// Paste inside / { } after behaviors {}
-#define KM_COND_LAYERS \
-    conditional_layers { \
-        compatible = "zmk,conditional-layers"; \
-        tri_media { \
-            if-layers = <NAV SYMBOLS>; \
-            then-layer = <MEDIA>; \
-        }; \
-        tri_system { \
-            if-layers = <NUMBERS FUNCTIONS>; \
-            then-layer = <SYSTEM>; \
-        }; \
-    };
+// ─── Conditional layers removed — outer thumb keys now use &lt MEDIA / &lt SYSTEM ───
+#define KM_COND_LAYERS /* unused */
 
 // ─── Thumb clusters ─────────────────────────────────────────────────────────
 // 4 middle thumbs — shared by all keyboards

--- a/config/boards/shields/sweep/sweep.keymap
+++ b/config/boards/shields/sweep/sweep.keymap
@@ -8,7 +8,7 @@
  *   Thumbs:    6 inner keys, plus 2 dummy &none at RC(3,1) and RC(3,10)
  *
  * Encoder-adjacent outer thumbs (RC(3,3), RC(3,8)):
- *   Base layer:  C_MUTE (left), C_PP (right)
+ *   Base layer:  &lt MEDIA C_MUTE (left), &lt SYSTEM C_PP (right)
  *   Media layer: C_PP (left), C_MUTE (right) — swapped
  *   System layer: &bootloader (left), &sys_reset (right)
  *   All other layers: &trans → falls through to base
@@ -60,7 +60,7 @@
                 &none  KM_BASE_R0  &none
                 &none  KM_BASE_R1  &none
                 &none  KM_BASE_R2  &none
-                &none  &kp C_MUTE  KM_MID_T  &kp C_PP  &none
+                &none  &lt MEDIA C_MUTE  KM_MID_T  &lt SYSTEM C_PP  &none
             >;
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };


### PR DESCRIPTION
## Changes

### Layer activation — outer thumb keys
- Removed conditional layers (tri_media, tri_system) — they conflicted with `&lt` layer-tap
- All keyboards now activate MEDIA by holding the **left outer thumb** and SYSTEM by holding the **right outer thumb**
- Sweep: `&lt MEDIA C_MUTE` (hold=media, tap=mute) / `&lt SYSTEM C_PP` (hold=system, tap=play/pause)
- Corne/Totem: already had `&lt MEDIA BSPC` / `&lt SYSTEM DEL` via KM_THUMBS

### Encoder rotation fix
- Added `CONFIG_EC11=y` + `CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y` to peripheral half configs (sweep_dongle_left.conf, sweep_right.conf)

### Transform alignment (44-position)
- All keyboards (sweep, totem, corne dongle) now have transforms matching the dongle exactly
- Fixes key mapping when using the universal dongle

### Trackpad
- Split input listener on dongle for receiving pointing data
- Smooth scrolling config on dongle
- Speed doubled (MOVE_VAL 5000, SCRL_VAL 40, sensitivity 3x)

### Other
- Corne RGB starts off (`CONFIG_ZMK_RGB_UNDERGLOW_ON_START=n`)
- Dongle POINTING/MOUSE config (from PR #10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)